### PR TITLE
Add support for other L versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 ![banner](https://banners.beyondco.de/Laravel%20Trongate.png?theme=dark&packageManager=composer+require&packageName=shitware-ltd%2Flaravel-trongate&pattern=architect&style=style_1&description=A+Trongate+adapter+for+Laravel.&md=1&showWatermark=0&fontSize=100px&images=https%3A%2F%2Flaravel.com%2Fimg%2Flogomark.min.svg)
 
+## Supported Laravel versions
+
+We believe in backwards compatability just as much as Trongate, below are the supported Laravel versions.
+
+- 7.x
+- 8.x
+- 9.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We believe in backwards compatability just as much as Trongate, below are the su
 
 - 7.x
 - 8.x
-- 9.
+- 9.x
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^9.0"
+        "laravel/framework": "^7.0|^8.0|^9.0"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Gotta make sure those people using older L versions can also integrate with Trongate.

Cleanware Ltd, providing fresh open source pull requests since 2022.